### PR TITLE
Nginx location for sca-mrcm-disabled app on UAT. Location will lead n…

### DIFF
--- a/roles/IHTSDO.sca/tasks/main.yml
+++ b/roles/IHTSDO.sca/tasks/main.yml
@@ -39,14 +39,18 @@
   lineinfile: 
      dest={{nginx_conf_dir}}{{nginx_conf}}.conf 
      insertbefore="^error_page 503 @maintenance;" 
-     line="location /sca {alias {{ lib_dir }}; 
-      if ( -f /opt/maint/maintain.html){
-        return 503;
-      }
-     }"
+     line="location /sca { alias {{ lib_dir }}; if ( -f /opt/maint/maintain.html){ return 503; } }"
      state=present
-     regexp='^location /sca'       
-       
+     regexp='^location /sca '
+
+- name: Add sca location to nginx config
+  lineinfile:
+     dest={{nginx_conf_dir}}{{nginx_conf}}.conf
+     insertbefore="^error_page 503 @maintenance;"
+     line="location /sca-mrcm-disabled { alias /opt/sca-no-mrcm/lib; if ( -f /opt/maint/maintain.html){ return 503; } }"
+     state=present
+     regexp='^location /sca-mrcm-disabled '
+
 - name: restart nginx
   service: name=nginx state=restarted  
 

--- a/roles/IHTSDO.sca/tasks/main.yml
+++ b/roles/IHTSDO.sca/tasks/main.yml
@@ -43,13 +43,14 @@
      state=present
      regexp='^location /sca '
 
-- name: Add sca location to nginx config
+- name: Add sca-mrcm-disabled location to nginx config
   lineinfile:
      dest={{nginx_conf_dir}}{{nginx_conf}}.conf
      insertbefore="^error_page 503 @maintenance;"
      line="location /sca-mrcm-disabled { alias /opt/sca-no-mrcm/lib; if ( -f /opt/maint/maintain.html){ return 503; } }"
      state=present
      regexp='^location /sca-mrcm-disabled '
+  when: ansible_hostname == "uat-term"
 
 - name: restart nginx
   service: name=nginx state=restarted  


### PR DESCRIPTION
…owhere on other systems.

This is to create an Nginx location to the manually deployed version of SCA, on UAT only, which has MRCM validation disabled. This meets a requirement from Jim Case to be able to try out some modeling without MRCM constraints. I have hardcoded the lib_dir since it's manually deployed there already. This is expected to fail if the UAT box is recreated.