### PR TITLE
Reconfig json conversion for 20170731 authoring cycle

### DIFF
--- a/roles/IHTSDO.daily-build-browser-json-conversion/defaults/main.yml
+++ b/roles/IHTSDO.daily-build-browser-json-conversion/defaults/main.yml
@@ -4,10 +4,10 @@ daily_build_dir: /opt/dailybuild
 force_zip_download: True
 rf2_json_conversion_enabled: True
 rf2_diff_report_enabled: True
-release_file_name: SnomedCT_RF2Release_INT_20170131.zip
-unpacked_release_file_name: SnomedCT_RF2Release_INT_20170131
-effectiveTime: 20170131
-expirationTime: 20170731
+release_file_name: SnomedCT_RF2Release_INT_20170731.zip
+unpacked_release_file_name: SnomedCT_RF2Release_INT_20170731
+effectiveTime: 20170731
+expirationTime: 20180131
 jsonOutputFolder: "{{ daily_build_dir }}/json"
 dailybuild_url: https://release.ihtsdotools.org/api/v1/centers/international/products/snomed_ct_ts_release/builds/
 snapshotFolder: "{{ daily_build_dir }}/{{ unpacked_release_file_name }}/Snapshot"
@@ -22,7 +22,7 @@ rf2_diff_json_file_name: diffReports.tgz
 rf2_diff_json_report_folder: "{{ daily_build_dir }}/diff_reports"
 rf2_diff_root_dir: /opt/rf2-diff-generator
 # One date after the previous release
-rf2_diff_start_date: 20160801
+rf2_diff_start_date: 20170801
 rf2_diff_json_s3_upload_script: uploadRf2DiffJsonToS3.sh
 rf2_diff_report_s3_upload_cmd:  "{{ rf2_diff_json_report_folder }}/{{ rf2_diff_json_s3_upload_script }}"
 config_xml: "enConfig.xml.j2"

--- a/roles/IHTSDO.daily-build-browser-json-import/defaults/main.yml
+++ b/roles/IHTSDO.daily-build-browser-json-import/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 edition_name: en-edition
 
-release_version: 20170131
+release_version: 20170731
 
 rf2json_s3_bucket_name: s3://daily-build-rf2-json.ihtsdo
 


### PR DESCRIPTION
Hi Dev-ops

I have reconfigured the daily build browser json import job. This job is disabled at the moment as Mapping team is still using the dailybuild browser to map the 20170131 contents which are just being done in the alpha release.  Once we need to enable the dailybuild for 20170731 authoring cycle can you please merge this change so that we can have the correct config.

(Note: We need to change effective date to 20170731 in the dailybuild index.html as well)

Thanks

Michael