### PR TITLE
Update US daily build config to use extension build

### DIFF
--- a/daily-build-browser-json-conversion-local-us.yml
+++ b/daily-build-browser-json-conversion-local-us.yml
@@ -4,16 +4,16 @@
     vars:
      rf2json_s3_bucket_name: s3://dailybuild-ihtsdo/us
      dailybuild_url: https://release.ihtsdotools.org/api/v1/centers/us/products/snomed_ct_us_daily_build/builds/
-     unpacked_release_file_name: SnomedCT_USEditionRF2_PRODUCTION_20180301T120000Z
+     unpacked_release_file_name: SnomedCT_USExtensionRF2_PRODUCTION_20180901T120000Z
      release_file_name: "{{unpacked_release_file_name}}.zip"
      config_xml: usConfig.xml.j2
      editionName: "US"
      ihtsdo_repository: release  
      #int_unpacked_release_file_name: "SnomedCT_InternationalRF2_Production_20170131T120000"  
-     effectiveTime: 20180301
+     effectiveTime: 20180901
      expirationTime: 20190301
      # One date after the previous release
-     rf2_diff_start_date: 20170902
+     rf2_diff_start_date: 20180302
     roles:
       - IHTSDO.aws
       - IHTSDO.daily-build-browser-json-conversion

--- a/daily-build-browser-json-import-us.yml
+++ b/daily-build-browser-json-import-us.yml
@@ -4,7 +4,7 @@
     vars:
      rf2json_s3_bucket_name: s3://dailybuild-ihtsdo/us
      edition_name: us-edition
-     release_version: 20180301
+     release_version: 20180901
      daily_build_import_dir: "/home/dailybuild-us"
     roles:
       - IHTSDO.aws


### PR DESCRIPTION
Hi Dev-Ops,
Can you please review and merge the changes for US daily build config update? I think we need to update existing ansible role to fetch the release zip file name and effective time values from the build Url or parameters from the Jenkin's job to avoid updating ansible scripts whenever these is a change in the config.

Thanks

Michael