### PR TITLE
Revert change for published bucket config until INFRA-2395 is fixed

### DIFF
--- a/roles/IHTSDO.daily-build-browser-json-conversion/defaults/main.yml
+++ b/roles/IHTSDO.daily-build-browser-json-conversion/defaults/main.yml
@@ -27,7 +27,7 @@ release_file_name: "{{unpacked_release_file_name}}.zip"
 
 int_release_s3_backup_region: "eu-west-1"
 int_release_dir: "/opt/IntRelease"
-int_release_s3_bucket_name: s3://release-ihtsdo-prod-published/international/
+int_release_s3_bucket_name: s3://ire.published.release.ihtsdo/international/
 int_unpacked_release_file_name: ""
 int_release_file_name: "{{int_unpacked_release_file_name}}.zip"
 int_release_s3_download: "{{int_release_s3_bucket_name}}{{int_release_file_name}}"
@@ -35,7 +35,7 @@ int_release_snapshotFolder: "{{ int_release_dir }}/{{ int_unpacked_release_file_
 
 snapshot_get_release: False
 snapshot_release_s3_backup_region: "eu-west-1"
-snapshot_release_s3_bucket_name: "s3://release-ihtsdo-prod-published/se/"
+snapshot_release_s3_bucket_name: "s3://ire.published.release.ihtsdo/se/"
 snapshot_release_s3_download: "{{snapshot_release_s3_bucket_name}}{{release_file_name}}"
 
 

--- a/snapshot-browser-json-conversion-local.yml
+++ b/snapshot-browser-json-conversion-local.yml
@@ -6,7 +6,7 @@
      rf2json_s3_bucket_name: "s3://ms-authoring-clean/rf2json/{{unpacked_release_file_name}}"
      unpacked_release_file_name: SnomedCT_SE_Production_20170531T120000
      release_file_name: "{{unpacked_release_file_name}}.zip"
-     snapshot_release_s3_bucket_name: "s3://release-ihtsdo-prod-published/se/"
+     snapshot_release_s3_bucket_name: "s3://ire.published.release.ihtsdo/se/"
 
      config_xml: seConfig.xml.j2
      editionName: "Swedish"


### PR DESCRIPTION
Revert change for new published bucket config so that we can use the old bucket for now until INFRA-2395 is done.